### PR TITLE
feat!: bump to 1.0.0 and enable npm publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,3 +63,24 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_REF: ${{ github.ref }}
+  release_npm:
+    name: Publish to npm
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    if: needs.release.outputs.latest_commit == github.sha
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: dist
+          path: dist
+      - name: Release
+        run: npx -p jsii-release@latest jsii-release-npm
+        env:
+          NPM_DIST_TAG: latest
+          NPM_REGISTRY: registry.npmjs.org
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    container:
+      image: jsii/superchain:node14

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -238,6 +238,22 @@
         }
       ]
     },
+    "publish:npm": {
+      "name": "publish:npm",
+      "description": "Publish this package to npm",
+      "env": {
+        "NPM_DIST_TAG": "latest",
+        "NPM_REGISTRY": "registry.npmjs.org"
+      },
+      "requiredEnv": [
+        "NPM_TOKEN"
+      ],
+      "steps": [
+        {
+          "exec": "npx -p jsii-release@latest jsii-release-npm"
+        }
+      ]
+    },
     "docgen": {
       "name": "docgen",
       "description": "Generate API.md from .jsii manifest",

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -42,9 +42,9 @@ const project = new AwsCdkConstructLibrary({
   ],
   // Release Configuration
   defaultReleaseBranch: "main",
-  // TODO: Turn these on as we're ready.
   packageName: "@aws/aws-domain-redirector",
-  releaseToNpm: false,
+  releaseToNpm: true,
+  // TODO: Turn these on as we're ready.
   publishToGo: false,
   publishToMaven: false,
   publishToNuget: false,

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "package": "npx projen package",
     "eslint": "npx projen eslint",
     "compat": "npx projen compat",
+    "publish:npm": "npx projen publish:npm",
     "docgen": "npx projen docgen",
     "release": "npx projen release",
     "projen": "npx projen"


### PR DESCRIPTION
*Description of changes:*

note: the `feat!` should trigger a major version bump through conventional commits

By submitting this pull request 
I confirm that you can use, modify, copy, and redistribute this contribution 
under the terms of your choice.