### PR TITLE
fix: publish npm package with public scope

### DIFF
--- a/.projenrc.js
+++ b/.projenrc.js
@@ -1,4 +1,4 @@
-const { AwsCdkConstructLibrary, ProjectType } = require("projen");
+const { AwsCdkConstructLibrary, ProjectType, NpmAccess } = require("projen");
 const project = new AwsCdkConstructLibrary({
   name: "aws-domain-redirector",
   description: "AWS CDK construct to redirect one domain to another.",
@@ -44,6 +44,7 @@ const project = new AwsCdkConstructLibrary({
   defaultReleaseBranch: "main",
   packageName: "@aws/aws-domain-redirector",
   releaseToNpm: true,
+  npmAccess: NpmAccess.PUBLIC,
   // TODO: Turn these on as we're ready.
   publishToGo: false,
   publishToMaven: false,

--- a/package.json
+++ b/package.json
@@ -83,6 +83,9 @@
   ],
   "main": "lib/index.js",
   "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "version": "0.0.0",
   "jest": {
     "testMatch": [


### PR DESCRIPTION
*Description of changes:*

Scoped npm packages public as restricted by default. This change makes it publish as public.

By submitting this pull request 
I confirm that you can use, modify, copy, and redistribute this contribution 
under the terms of your choice.